### PR TITLE
Add high score tracking with player name input

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,11 @@
             <span class="label">Score</span>
             <span id="scoreValue">0</span>
           </div>
+          <div class="high-score">
+            <span class="label">High Score</span>
+            <span class="value" id="highScoreValue">0</span>
+            <span class="name" id="highScoreName">---</span>
+          </div>
           <div class="controls">
             <button id="startBtn" type="button">Start</button>
             <button id="pauseBtn" type="button" disabled>Pause</button>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,8 @@ const startBtn = document.getElementById('startBtn');
 const pauseBtn = document.getElementById('pauseBtn');
 const resetBtn = document.getElementById('resetBtn');
 const scoreValue = document.getElementById('scoreValue');
+const highScoreValue = document.getElementById('highScoreValue');
+const highScoreName = document.getElementById('highScoreName');
 
 let snake = [];
 let direction = { x: 1, y: 0 };
@@ -19,6 +21,7 @@ let intervalId = null;
 let isRunning = false;
 let isGameOver = false;
 let hasStarted = false;
+let highScore = loadHighScore();
 
 const keyMap = {
   ArrowUp: { x: 0, y: -1 },
@@ -34,6 +37,7 @@ const keyMap = {
 function init() {
   resetGame();
   drawBoard();
+  updateHighScoreDisplay();
 }
 
 function resetGame() {
@@ -149,6 +153,16 @@ function isCollision(head) {
 function handleGameOver() {
   stopGame();
   isGameOver = true;
+  if (score > highScore.score) {
+    const namePrompt = prompt('New high score! Enter your name:', highScore.name !== '---' ? highScore.name : '') ?? '';
+    const trimmedName = namePrompt.trim() || 'Anonymous';
+    highScore = {
+      score,
+      name: trimmedName,
+    };
+    saveHighScore();
+    updateHighScoreDisplay();
+  }
   updateButtons();
   drawBoard();
 }
@@ -162,6 +176,37 @@ function drawBoard() {
   if (isGameOver) {
     drawGameOver();
   }
+}
+
+function loadHighScore() {
+  try {
+    const stored = localStorage.getItem('snakeHighScore');
+    if (!stored) {
+      return { score: 0, name: '---' };
+    }
+    const parsed = JSON.parse(stored);
+    const storedScore = Number(parsed.score);
+    if (!Number.isFinite(storedScore) || storedScore < 0) {
+      return { score: 0, name: '---' };
+    }
+    const storedName = typeof parsed.name === 'string' && parsed.name.trim() !== '' ? parsed.name.trim() : '---';
+    return { score: storedScore, name: storedName };
+  } catch (error) {
+    return { score: 0, name: '---' };
+  }
+}
+
+function saveHighScore() {
+  try {
+    localStorage.setItem('snakeHighScore', JSON.stringify(highScore));
+  } catch (error) {
+    // Ignore write errors (e.g., storage disabled)
+  }
+}
+
+function updateHighScoreDisplay() {
+  highScoreValue.textContent = highScore.score;
+  highScoreName.textContent = highScore.name || '---';
 }
 
 function drawGrid() {

--- a/styles.css
+++ b/styles.css
@@ -63,7 +63,8 @@ body {
   width: 100%;
 }
 
-.score {
+.score,
+.high-score {
   background: rgba(148, 163, 184, 0.12);
   padding: 0.75rem 1.5rem;
   border-radius: 9999px;
@@ -72,16 +73,26 @@ body {
   gap: 0.75rem;
 }
 
-.score .label {
+.score .label,
+.high-score .label {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.8rem;
   color: var(--muted);
 }
 
-.score #scoreValue {
+.score #scoreValue,
+.high-score .value {
   font-weight: 700;
   font-size: 1.5rem;
+}
+
+.high-score .name {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- display the current high score alongside the in-game HUD
- prompt the player for their name when they set a new record and persist it in local storage

## Testing
- Manual testing in browser

------
https://chatgpt.com/codex/tasks/task_e_68daf658550c832db550a616fccee3c0